### PR TITLE
Changes to Note Controller & Changed Create & Update streams to not b…

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -25,15 +25,13 @@ class NotesController < ApplicationController
     if @note.update(note_params)
       respond_to do |format|
         format.html { redirect_to favorites_path, notice: "Note updated!" }
-
-        format.turbo_stream do
-          render partial: "notes/update", formats: :turbo_stream, locals: { recipe: @recipe, note: @note }
-        end
+        format.turbo_stream
       end
     else
       redirect_to favorites_path(edit_recipe_id: @recipe.id), alert: "Couldn't update note."
     end
   end
+
 
   def destroy
   end

--- a/app/views/notes/_create.turbo_stream.erb
+++ b/app/views/notes/_create.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace "note_container_#{recipe.id}" do %>
-  <%= render partial: "shared/cookbook_card", locals: { recipe: recipe } %>
-<% end %>

--- a/app/views/notes/_update.turbo_stream.erb
+++ b/app/views/notes/_update.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace "note_container_#{recipe.id}" do %>
-  <%= render partial: "shared/cookbook_card", locals: { recipe: recipe } %>
-<% end %>

--- a/app/views/notes/create.turbo_stream.erb
+++ b/app/views/notes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "note_container_#{@recipe.id}" do %>
+  <%= render partial: "shared/cookbook_card", locals: { recipe: @recipe } %>
+<% end %>

--- a/app/views/notes/update.turbo_stream.erb
+++ b/app/views/notes/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "note_container_#{@recipe.id}" do %>
+  <%= render partial: "shared/cookbook_card", locals: { recipe: @recipe } %>
+<% end %>

--- a/app/views/shared/_cookbook_card.html.erb
+++ b/app/views/shared/_cookbook_card.html.erb
@@ -1,5 +1,5 @@
+<div id="note_container_<%= recipe.id %>">
   <div id="recipe_card_<%= recipe.id %>">
-    <div id="note_container_<%= recipe.id %>">
     <div class="recipe-container">
         <%= render partial: "shared/card", locals: { recipe: recipe } %>
 


### PR DESCRIPTION
* Removed "_" from the turbo-stream create & update templates - since they aren't partials
* Changed the Update action in the controller from this

`def update
    @note = @recipe.notes.find_by(user: current_user)

    if @note.update(note_params)
      respond_to do |format|
        format.html { redirect_to favorites_path, notice: "Note updated!" }

        format.turbo_stream do
          render partial: "notes/update", formats: :turbo_stream, locals: { recipe: @recipe, note: @note }
        end
      end
    else
      redirect_to favorites_path(edit_recipe_id: @recipe.id), alert: "Couldn't update note."
    end
  end`


to this


`def update
    @note = @recipe.notes.find_by(user: current_user)

    if @note.update(note_params)
      respond_to do |format|
        format.html { redirect_to favorites_path, notice: "Note updated!" }
        format.turbo_stream
      end
    else
      redirect_to favorites_path(edit_recipe_id: @recipe.id), alert: "Couldn't update note."
    end
  end`
  
  * Moved the recipe note container to the top level in the cookbook_card partial